### PR TITLE
Issue 22 - Add a way to store user names

### DIFF
--- a/data/allpasswords/allpasswords.html
+++ b/data/allpasswords/allpasswords.html
@@ -40,9 +40,9 @@
     <div id="password-template" hidden>
       <div class="password-container">
         <div class="password-copied-message success" data-l10n-id="password-copied-message" hidden></div>
-        <div class="password-name-container">
+        <div class="user-name-container">
           <a href="#" class="to-clipboard-link" data-l10n-id="to-clipboard"></a>
-          <span class="password-name"></span>
+          <span class="user-name"></span>
           <a href="#" class="password-remove-link" data-l10n-id="remove-password"></a>
         </div>
         <div class="password-info generated">

--- a/data/allpasswords/allpasswords.less
+++ b/data/allpasswords/allpasswords.less
@@ -188,14 +188,14 @@ body
   background-color: @hover-background;
 }
 
-.password-name-container
+.user-name-container
 {
   display: flex;
   flex-direction: row;
   align-items: center;
 }
 
-.password-name
+.user-name
 {
   font-weight: bold;
   flex-grow: 1;

--- a/data/allpasswords/main.js
+++ b/data/allpasswords/main.js
@@ -179,7 +179,7 @@ port.on("init", function(sites)
     {
       let passwordData = passwords[name];
       let passwordInfo = passwordTemplate.cloneNode(true);
-      passwordInfo.querySelector(".password-name").textContent = name;
+      passwordInfo.querySelector(".user-name").textContent = name;
 
       setCommandHandler(passwordInfo.querySelector(".to-clipboard-link"), copyToClipboard.bind(null, site, name, passwordInfo));
       setCommandHandler(passwordInfo.querySelector(".password-remove-link"), removePassword.bind(null, site, name, passwordInfo));

--- a/data/panel/generatePassword.js
+++ b/data/panel/generatePassword.js
@@ -13,8 +13,6 @@ let {setValidator, markInvalid, enforceValue} = require("./formValidation");
 let state = require("./state");
 let {$, setActivePanel, showUnknownError, messages} = require("./utils");
 
-$("generate-password-name").setAttribute("placeholder", messages["password-name-hint"]);
-
 $("password-length").addEventListener("input", updatePasswordLengthDisplay);
 $("generate-password").addEventListener("reset", () =>
 {
@@ -22,7 +20,7 @@ $("generate-password").addEventListener("reset", () =>
 });
 updatePasswordLengthDisplay();
 
-setValidator("generate-password-name", enforceValue.bind(null, "password-name-required"));
+setValidator("generate-password-user-name", enforceValue.bind(null, "user-name-required"));
 setValidator(["charset-lower", "charset-upper", "charset-number", "charset-symbol"], validateCharsets);
 
 setSubmitHandler("generate-password", addGeneratedPassword);
@@ -53,7 +51,7 @@ function addGeneratedPassword()
 {
   passwords.addGenerated({
     site: state.site,
-    name: $("generate-password-name").value,
+    name: $("generate-password-user-name").value,
     length: $("password-length").value,
     lower: $("charset-lower").checked,
     upper: $("charset-upper").checked,
@@ -66,7 +64,7 @@ function addGeneratedPassword()
   }).catch(error =>
   {
     if (error == "alreadyExists")
-      markInvalid("generate-password-name", messages["password-name-exists"]);
+      markInvalid("generate-password-user-name", messages["user-name-exists"]);
     else
       showUnknownError(error);
   });

--- a/data/panel/legacyPassword.js
+++ b/data/panel/legacyPassword.js
@@ -13,9 +13,7 @@ let {setValidator, markInvalid, enforceValue} = require("./formValidation");
 let state = require("./state");
 let {$, setActivePanel, showUnknownError, messages} = require("./utils");
 
-$("legacy-password-name").setAttribute("placeholder", messages["password-name-hint"]);
-
-setValidator("legacy-password-name", enforceValue.bind(null, "password-name-required"));
+setValidator("legacy-password-user-name", enforceValue.bind(null, "user-name-required"));
 setValidator("legacy-password-value", enforceValue.bind(null, "password-value-required"));
 
 setSubmitHandler("legacy-password", addLegacyPassword);
@@ -42,7 +40,7 @@ function addLegacyPassword()
 {
   passwords.addLegacy({
     site: state.site,
-    name: $("legacy-password-name").value,
+    name: $("legacy-password-user-name").value,
     password: $("legacy-password-value").value
   }).then(pwdList =>
   {
@@ -51,7 +49,7 @@ function addLegacyPassword()
   }).catch(error =>
   {
     if (error == "alreadyExists")
-      markInvalid("legacy-password-name", messages["password-name-exists"]);
+      markInvalid("legacy-password-user-name", messages["user-name-exists"]);
     else
       showUnknownError(error);
   });

--- a/data/panel/panel.html
+++ b/data/panel/panel.html
@@ -21,9 +21,8 @@
       <div data-l10n-id="passwords-differ"></div>
       <div data-l10n-id="weak-password"></div>
       <div data-l10n-id="password-declined"></div>
-      <div data-l10n-id="password-name-hint"></div>
-      <div data-l10n-id="password-name-required"></div>
-      <div data-l10n-id="password-name-exists"></div>
+      <div data-l10n-id="user-name-required"></div>
+      <div data-l10n-id="user-name-exists"></div>
       <div data-l10n-id="no-characters-selected"></div>
       <div data-l10n-id="password-value-required"></div>
       <div data-l10n-id="password-type-generated"></div>
@@ -78,7 +77,7 @@
         <div class="password-container">
           <a href="#" class="to-document-link" data-l10n-id="to-document"></a>
           <a href="#" class="to-clipboard-link" data-l10n-id="to-clipboard"></a>
-          <span class="password-name"></span>
+          <span class="user-name"></span>
           <a href="#" class="password-remove-link" data-l10n-id="remove-password"></a>
         </div>
       </div>
@@ -116,11 +115,11 @@
       </div>
     </form>
 
-    <form id="generate-password" class="slide" data-default-element="generate-password-name">
+    <form id="generate-password" class="slide" data-default-element="generate-password-user-name">
       <label data-l10n-id="site"></label>
       <div id="generate-password-site"></div>
-      <label class="block-start" for="generate-password-name" data-l10n-id="password-name"></label>
-      <input id="generate-password-name" type="text">
+      <label class="block-start" for="generate-password-user-name" data-l10n-id="user-name"></label>
+      <input id="generate-password-user-name" type="text">
       <div class="error" hidden></div>
       <label class="block-start" for="password-length" data-l10n-id="password-length"></label>
       <div id="length-container">
@@ -141,11 +140,11 @@
       </div>
     </form>
 
-    <form id="legacy-password" class="slide" data-default-element="legacy-password-name">
+    <form id="legacy-password" class="slide" data-default-element="legacy-password-user-name">
       <label data-l10n-id="site"></label>
       <div id="legacy-password-site"></div>
-      <label class="block-start" for="legacy-password-name" data-l10n-id="password-name"></label>
-      <input id="legacy-password-name" type="text">
+      <label class="block-start" for="legacy-password-user-name" data-l10n-id="user-name"></label>
+      <input id="legacy-password-user-name" type="text">
       <div class="error" hidden></div>
       <label class="block-start" for="legacy-password-value" data-l10n-id="password-value"></label>
       <input id="legacy-password-value" type="password">

--- a/data/panel/panel.less
+++ b/data/panel/panel.less
@@ -259,7 +259,7 @@ a:hover
   background-color: @hover-background;
 }
 
-.password-name
+.user-name
 {
   flex-grow: 1;
 }
@@ -301,7 +301,7 @@ a:hover
 }
 
 #generate-password-site,
-#generate-password-name,
+#generate-password-user-name,
 #length-container,
 #charsets-container
 {

--- a/data/panel/passwordList.js
+++ b/data/panel/passwordList.js
@@ -223,7 +223,7 @@ function showPasswords()
       setCommandHandler(entry.querySelector(".to-clipboard-link"), copyToClipboard.bind(null, name));
       setCommandHandler(entry.querySelector(".password-remove-link"), removePassword.bind(null, name));
 
-      let nameNode = entry.querySelector(".password-name");
+      let nameNode = entry.querySelector(".user-name");
       nameNode.textContent = name;
       nameNode.setAttribute("title", tooltip);
 

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -3,9 +3,8 @@ password-too-short = The master password should be at least 6 characters long.
 passwords-differ = Passwords don't match.
 weak-password = Your master password is too simple and wouldn't take long enough to guess. It is recommended that you choose a more complicated password. Do you really want to proceed with this master password?
 password-declined = This doesn't seem to be the master password you have used before.
-password-name-hint = Your user name or anything else
-password-name-required = Please enter an arbitrary password name.
-password-name-exists = This password name already exists.
+user-name-required = Please enter your user name or an arbitrary name if the website doesn't require one.
+user-name-exists = This user name already exists.
 no-characters-selected = At least one character set has to be selected.
 password-value-required = Please enter the password you used on this website.
 password-type-generated = Generated password
@@ -57,7 +56,7 @@ generate-password-link = Generate new password
 legacy-password-link = Enter legacy password
 
 # generate-password
-password-name = Password name:
+user-name = User name:
 password-length = Length:
 allowed-characters = Allowed characters:
 generate-password = Generate password


### PR DESCRIPTION
So this isn't ready to be merged yet but hopefully it's close. A few notes/questions:

 - It seems that for Chrome at least the `\0` is lost when saving / loading to storage.
 - Do you think the interface around revisions looks OK? For example what about how I've made that automatic for legacy passwords?
 - I'm not too happy about how the password's revision property exists to start with when the password is created, but after that the code constantly has to split it out of the password's name. However since the password's key is it's ID I didn't want to mess with it either.
 - I've passed in the revision when actually saving the passwords, I'm not sure if that's the right thing to do or not.
 - So far I didn't strip the revision part of the user name for messages such as "Are you sure you want to delete this?".