### PR TITLE
Highlight the site when creating an alias

### DIFF
--- a/data/panel/passwordList.js
+++ b/data/panel/passwordList.js
@@ -112,6 +112,7 @@ function editSite()
   let field = $("site");
   field.removeAttribute("readonly");
   field.value = state.site;
+  field.select();
   field.focus();
 }
 


### PR DESCRIPTION
I figured highlighting the existing site domain when creating an alias would be convenient. If typing a subdomain you can now just press the left arrow to jump to the start of the current domain. If typing a totally different domain you can simply start typing.