### PR TITLE
Issue 26 - Add importer for LastPass CSV files

### DIFF
--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -205,10 +205,24 @@ exports.runTests = function()
   let atob = str => new Buffer(str, "base64").toString("binary");
   let btoa = str => new Buffer(str, "binary").toString("base64");
 
+  let document = {
+    createElement()
+    {
+      return Object.create(null, {
+        value: {
+          get(s)
+          {
+            return (this.innerHTML || "").replace(/&amp;/g, "&");
+          }
+        }
+      });
+    }
+  };
+
   let nodeunit = require("sandboxed-module").require("nodeunit", {
     sourceTransformers: {rewriteRequires},
     globals: {
-      TextEncoder, TextDecoder, crypto, atob, btoa,
+      TextEncoder, TextDecoder, crypto, atob, btoa, document,
       Worker: WorkerWrapper
     }
   });

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -205,24 +205,10 @@ exports.runTests = function()
   let atob = str => new Buffer(str, "base64").toString("binary");
   let btoa = str => new Buffer(str, "binary").toString("base64");
 
-  let document = {
-    createElement()
-    {
-      return Object.create(null, {
-        value: {
-          get(s)
-          {
-            return (this.innerHTML || "").replace(/&amp;/g, "&");
-          }
-        }
-      });
-    }
-  };
-
   let nodeunit = require("sandboxed-module").require("nodeunit", {
     sourceTransformers: {rewriteRequires},
     globals: {
-      TextEncoder, TextDecoder, crypto, atob, btoa, document,
+      TextEncoder, TextDecoder, crypto, atob, btoa,
       Worker: WorkerWrapper
     }
   });

--- a/gulp-utils.js
+++ b/gulp-utils.js
@@ -204,11 +204,12 @@ exports.runTests = function()
   let crypto = require("./test-lib/fake-crypto");
   let atob = str => new Buffer(str, "base64").toString("binary");
   let btoa = str => new Buffer(str, "binary").toString("base64");
+  let {URL} = require("url");
 
   let nodeunit = require("sandboxed-module").require("nodeunit", {
     sourceTransformers: {rewriteRequires},
     globals: {
-      TextEncoder, TextDecoder, crypto, atob, btoa,
+      TextEncoder, TextDecoder, crypto, atob, btoa, URL,
       Worker: WorkerWrapper
     }
   });

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -6,37 +6,39 @@
 
 "use strict";
 
-/* global document */
-
 const parseURL = require("url").parse;
-
-const header = "url,username,password,extra,name,grouping,fav";
-exports.header = header;
-
-// If the Lastpass binary component is installed the CSV file is saved directly.
-// Otherwise some JavaScript creates a pre element and assigns the contents to
-// its innerHTML which has the side-effect of encoding HMTL entities. We assume
-// encoding happened, but if it didn't passwords or notes containing entities
-// will unfortunately be corrupted.
-// http://stackoverflow.com/a/7394787/1226469
-function decodeHTMLEntities(encoded)
-{
-  let textarea = document.createElement("textarea");
-  textarea.innerHTML = encoded;
-  return textarea.value;
-}
 
 function parseCSV(fileContents)
 {
-  const expectedValueCount = header.split(",").length;
+  const header = "url,username,password,extra,name,grouping,fav";
+  const headerFields = header.split(",");
+
+  fileContents = fileContents.trim();
+
+  // Quick sanity check, does this file have the right header?
+  if (!fileContents.startsWith(header))
+    throw "unknown-data-format";
+
+  // Ensure we've got UNIX style line endings
+  fileContents = fileContents.replace(/\r\n/g, "\n");
+
+  // Decode any HTML entities.
+  // Note: If the Lastpass binary component is installed the CSV file is saved
+  // directly, otherwise the contents are displayed in the browser for the user
+  // to save manually. It seems that the "&", "<" and ">" characters are only
+  // HTML encoded when the user saves the contents manually, we assume that's
+  // the case here, but if not any passwords or notes containing HTML encoded
+  // versions of those characters will be corrupted.
+  fileContents = fileContents.replace(/&amp;/ig, "&")
+                             .replace(/&lt;/ig, "<")
+                             .replace(/&gt;/ig, ">");
+  fileContents += "\n";
 
   let entries = [];
   let currentEntry = [];
   let currentValue = "";
   let currentlyQuoted = false;
   let currentLine = 0;
-
-  fileContents = fileContents.trim() + "\n";
 
   for (let i = 0; i < fileContents.length; i++)
   {
@@ -69,15 +71,17 @@ function parseCSV(fileContents)
         {
           currentEntry.push(currentValue);
           currentValue = "";
-          if (currentEntry.length != expectedValueCount)
+          if (currentEntry.length != headerFields.length)
           {
-            throw new Error(
-              "Line " + currentLine + ": Wrong number of values for entry. " +
-              "Saw " + currentEntry.length + ", but expected " +
-              expectedValueCount + "."
-            );
+            // FIXME - How to localise?
+            throw "csv-wrong-number-of-values";
+            // [currentLine, currentEntry.length, headerFields.length]
           }
-          entries.push(currentEntry);
+
+          let entry = {};
+          for (let j = 0; j < headerFields.length; j++)
+            entry[headerFields[j]] = currentEntry[j];
+          entries.push(entry);
           currentEntry = [];
         }
         else
@@ -91,9 +95,8 @@ function parseCSV(fileContents)
 
   if (currentlyQuoted)
   {
-    throw new Error(
-      "Syntax error, quotation mark was opened but never closed!"
-    );
+    // FIXME - How to localise?
+    throw "csv-unclosed-quote";
   }
 
   return entries;
@@ -104,25 +107,12 @@ function import_(data, setRaw, setSite, setPassword)
 {
   return Promise.resolve().then(() =>
   {
-    // Quick sanity check, does this file have the right header?
-    if (!data.trim().startsWith(header + "\n"))
-      throw "unknown-data-format";
-
     let mergeActions = [];
 
     let seenSites = new Set();
-    let entries;
-    try
+    let entries = parseCSV(data);
+    for (let {url, username, password, extra, name} of entries)
     {
-      entries = parseCSV(decodeHTMLEntities(data));
-    }
-    catch (e)
-    {
-      throw "unknown-data-format";
-    }
-    for (let i = 1; i < entries.length; i++)
-    {
-      let [url, username, password, extra, name, grouping, fav] = entries[i];
       let entry = {};
 
       let site;
@@ -134,21 +124,36 @@ function import_(data, setRaw, setSite, setPassword)
       }
       else
       {
+        let hostname = parseURL(url).hostname;
+
         // The url field is optional for LastPass entries and isn't validated.
-        // FIXME - Perhaps we should use .host rather than hostname?
-        let hostname = parseURL(url || name).hostname;
+        // Sometimes the default name LastPass uses actually is the hostname,
+        // so let's try to reuse that.
+        if (!hostname && name.includes(".") && name.length > 2 &&
+            !name.startsWith(".") && !/[\s|\/|A-Z]/.test(name))
+        {
+          hostname = parseURL("http://" + name).hostname;
+        }
+
         if (hostname)
         {
-          // FIXME - Duplicated from _normalizeSite in passwords.js, since we
-          //         don't want a circular dependency.
-          if (hostname.substr(0, 4) == "www.")
-            hostname = hostname.substr(4);
           site = hostname;
+
+          // FIXME - Duplicated from _normalizeSite in passwords.js
+          // Remove trailing dots
+          if (site[site.length - 1] == ".")
+            site = site.substr(0, site.length - 1);
+
+          // Remove www. prefix
+          if (site.substr(0, 4) == "www.")
+            site = site.substr(4);
         }
         else
         {
-          // FIXME - Do we really want to import bogus hostnames?!
-          site = url || name;
+          // FIXME - Should be localised and shown to the user afterwards as
+          //         a warning.
+          // throw "skipped-entry-missing-url", [name];
+          continue;
         }
       }
 
@@ -165,13 +170,9 @@ function import_(data, setRaw, setSite, setPassword)
 
       if (extra || password)
       {
-        let entry = {site, type: "stored", name: username};
-
+        let entry = {site, type: "stored", name: username, password};
         if (extra)
           entry.notes = extra;
-        if (password)
-          entry.password = password;
-
         mergeActions.push(setPassword(entry));
       }
     }

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -6,7 +6,7 @@
 
 "use strict";
 
-const parseURL = require("url").parse;
+/* global URL */
 
 function parseCSV(fileContents)
 {
@@ -15,12 +15,12 @@ function parseCSV(fileContents)
 
   fileContents = fileContents.trim();
 
-  // Quick sanity check, does this file have the right header?
-  if (!fileContents.startsWith(header))
-    throw "unknown-data-format";
-
   // Ensure we've got UNIX style line endings
   fileContents = fileContents.replace(/\r\n/g, "\n");
+
+  // Quick sanity check, does this file have the right header?
+  if (!fileContents.startsWith(header + "\n"))
+    throw "unknown-data-format";
 
   // Decode any HTML entities.
   // Note: If the Lastpass binary component is installed the CSV file is saved
@@ -29,9 +29,9 @@ function parseCSV(fileContents)
   // HTML encoded when the user saves the contents manually, we assume that's
   // the case here, but if not any passwords or notes containing HTML encoded
   // versions of those characters will be corrupted.
-  fileContents = fileContents.replace(/&amp;/ig, "&")
-                             .replace(/&lt;/ig, "<")
-                             .replace(/&gt;/ig, ">");
+  fileContents = fileContents.replace(/&lt;/ig, "<")
+                             .replace(/&gt;/ig, ">")
+                             .replace(/&amp;/ig, "&");
   fileContents += "\n";
 
   let entries = [];
@@ -113,8 +113,6 @@ function import_(data, setRaw, setSite, setPassword)
     let entries = parseCSV(data);
     for (let {url, username, password, extra, name} of entries)
     {
-      let entry = {};
-
       let site;
       if (url == "http://sn")
       {
@@ -124,21 +122,22 @@ function import_(data, setRaw, setSite, setPassword)
       }
       else
       {
-        let hostname = parseURL(url).hostname;
+        try
+        {
+          site = new URL(url).hostname;
+        }
+        catch (e)
+        {
+        }
 
         // The url field is optional for LastPass entries and isn't validated.
         // Sometimes the default name LastPass uses actually is the hostname,
         // so let's try to reuse that.
-        if (!hostname && name.includes(".") && name.length > 2 &&
-            !name.startsWith(".") && !/[\s|\/|A-Z]/.test(name))
-        {
-          hostname = parseURL("http://" + name).hostname;
-        }
+        if (!site && name.includes(".") && !/[\s\/]/.test(name))
+          site = name;
 
-        if (hostname)
+        if (site)
         {
-          site = hostname;
-
           // FIXME - Duplicated from _normalizeSite in passwords.js
           // Remove trailing dots
           if (site[site.length - 1] == ".")

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -110,7 +110,7 @@ function import_(data, setRaw, setSite, setPassword)
 
     let mergeActions = [];
 
-    let seenDomains = new Set();
+    let seenSites = new Set();
     let entries;
     try
     {
@@ -125,34 +125,47 @@ function import_(data, setRaw, setSite, setPassword)
       let [url, username, password, extra, name, grouping, fav] = entries[i];
       let entry = {};
 
-      // Secure notes aren't always associated with a webpage (they're given the
-      // special URL "http://sn") or a username in LastPass. Let's clear that
-      // URL and reuse the note's name if the username is missing.
+      let site;
       if (url == "http://sn")
       {
-        url = "";
-        if (!username && name && extra)
-          username = name;
+        // Secure notes with no associated webpage are given the special URL of
+        // "http://sn" by LastPass.
+        site = "easypasswords.invalid";
+      }
+      else
+      {
+        // The url field is optional for LastPass entries and isn't validated.
+        // FIXME - Perhaps we should use .host rather than hostname?
+        let hostname = parseURL(url || name).hostname;
+        if (hostname)
+        {
+          // FIXME - Duplicated from _normalizeSite in passwords.js, since we
+          //         don't want a circular dependency.
+          if (hostname.substr(0, 4) == "www.")
+            hostname = hostname.substr(4);
+          site = hostname;
+        }
+        else
+        {
+          // FIXME - Do we really want to import bogus hostnames?!
+          site = url || name;
+        }
       }
 
-      // FIXME - Perhaps we should use .host rather than hostname?
-      // FIXME - Do we really want to import potentially bogus hostnames?!
-      let domain = parseURL(url).hostname || url || "easypasswords.invalid";
+      // For secure notes with no associated username or password let's reuse
+      // their name.
+      if (!username && name && extra && !password)
+        username = name;
 
-      // FIXME - Duplicated from _normalizeSite in passwords.js, since we don't
-      //         want a circular dependency.
-      if (domain.substr(0, 4) == "www.")
-        domain = domain.substr(4);
-
-      if (!seenDomains.has(domain))
+      if (!seenSites.has(site))
       {
-        mergeActions.push(setSite({site: domain}));
-        seenDomains.add(domain);
+        mergeActions.push(setSite({site}));
+        seenSites.add(site);
       }
 
       if (extra || password)
       {
-        let entry = {site: domain, type: "stored", name: username};
+        let entry = {site, type: "stored", name: username};
 
         if (extra)
           entry.notes = extra;

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -152,16 +152,12 @@ function import_(data, setRaw, setSite, setPassword)
 
       if (extra || password)
       {
-        let entry = {site: domain, type: "stored"};
+        let entry = {site: domain, type: "stored", name: username};
 
         if (extra)
           entry.notes = extra;
-
         if (password)
-        {
-          entry.name = username;
           entry.password = password;
-        }
 
         mergeActions.push(setPassword(entry));
       }

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -22,13 +22,8 @@ function parseCSV(fileContents)
   if (!fileContents.startsWith(header + "\n"))
     throw "unknown-data-format";
 
-  // Decode any HTML entities.
-  // Note: If the Lastpass binary component is installed the CSV file is saved
-  // directly, otherwise the contents are displayed in the browser for the user
-  // to save manually. It seems that the "&", "<" and ">" characters are only
-  // HTML encoded when the user saves the contents manually, we assume that's
-  // the case here, but if not any passwords or notes containing HTML encoded
-  // versions of those characters will be corrupted.
+  // LastPass will sometimes encode "&", "<" and ">" into HTML entities when
+  // exporting data, revert that.
   fileContents = fileContents.replace(/&lt;/ig, "<")
                              .replace(/&gt;/ig, ">")
                              .replace(/&amp;/ig, "&");

--- a/lib/importers/lastPass.js
+++ b/lib/importers/lastPass.js
@@ -1,0 +1,172 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the "License"). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+"use strict";
+
+/* global document */
+
+const parseURL = require("url").parse;
+
+const header = "url,username,password,extra,name,grouping,fav";
+exports.header = header;
+
+// If the Lastpass binary component is installed the CSV file is saved directly.
+// Otherwise some JavaScript creates a pre element and assigns the contents to
+// its innerHTML which has the side-effect of encoding HMTL entities. We assume
+// encoding happened, but if it didn't passwords or notes containing entities
+// will unfortunately be corrupted.
+// http://stackoverflow.com/a/7394787/1226469
+function decodeHTMLEntities(encoded)
+{
+  let textarea = document.createElement("textarea");
+  textarea.innerHTML = encoded;
+  return textarea.value;
+}
+
+function parseCSV(fileContents)
+{
+  const expectedValueCount = header.split(",").length;
+
+  let entries = [];
+  let currentEntry = [];
+  let currentValue = "";
+  let currentlyQuoted = false;
+  let currentLine = 0;
+
+  fileContents = fileContents.trim() + "\n";
+
+  for (let i = 0; i < fileContents.length; i++)
+  {
+    let currentChar = fileContents[i];
+    switch (currentChar)
+    {
+      case "\"":
+        if (!currentlyQuoted)
+          currentlyQuoted = true;
+        else if (i + 1 < fileContents.length &&
+                 fileContents[i + 1] == "\"")
+        {
+          currentValue += currentChar;
+          i++;
+        }
+        else
+          currentlyQuoted = false;
+        break;
+      case ",":
+        if (!currentlyQuoted)
+        {
+          currentEntry.push(currentValue);
+          currentValue = "";
+        }
+        else
+          currentValue += currentChar;
+        break;
+      case "\n":
+        if (!currentlyQuoted)
+        {
+          currentEntry.push(currentValue);
+          currentValue = "";
+          if (currentEntry.length != expectedValueCount)
+          {
+            throw new Error(
+              "Line " + currentLine + ": Wrong number of values for entry. " +
+              "Saw " + currentEntry.length + ", but expected " +
+              expectedValueCount + "."
+            );
+          }
+          entries.push(currentEntry);
+          currentEntry = [];
+        }
+        else
+          currentValue += currentChar;
+        currentLine++;
+        break;
+      default:
+        currentValue += currentChar;
+    }
+  }
+
+  if (currentlyQuoted)
+  {
+    throw new Error(
+      "Syntax error, quotation mark was opened but never closed!"
+    );
+  }
+
+  return entries;
+}
+exports.parseCSV = parseCSV;
+
+function import_(data, setRaw, setSite, setPassword)
+{
+  return Promise.resolve().then(() =>
+  {
+    // Quick sanity check, does this file have the right header?
+    if (!data.trim().startsWith(header + "\n"))
+      throw "unknown-data-format";
+
+    let mergeActions = [];
+
+    let seenDomains = new Set();
+    let entries;
+    try
+    {
+      entries = parseCSV(decodeHTMLEntities(data));
+    }
+    catch (e)
+    {
+      throw "unknown-data-format";
+    }
+    for (let i = 1; i < entries.length; i++)
+    {
+      let [url, username, password, extra, name, grouping, fav] = entries[i];
+      let entry = {};
+
+      // Secure notes aren't always associated with a webpage (they're given the
+      // special URL "http://sn") or a username in LastPass. Let's clear that
+      // URL and reuse the note's name if the username is missing.
+      if (url == "http://sn")
+      {
+        url = "";
+        if (!username && name && extra)
+          username = name;
+      }
+
+      // FIXME - Perhaps we should use .host rather than hostname?
+      // FIXME - Do we really want to import potentially bogus hostnames?!
+      let domain = parseURL(url).hostname || url || "easypasswords.invalid";
+
+      // FIXME - Duplicated from _normalizeSite in passwords.js, since we don't
+      //         want a circular dependency.
+      if (domain.substr(0, 4) == "www.")
+        domain = domain.substr(4);
+
+      if (!seenDomains.has(domain))
+      {
+        mergeActions.push(setSite({site: domain}));
+        seenDomains.add(domain);
+      }
+
+      if (extra || password)
+      {
+        let entry = {site: domain, type: "stored"};
+
+        if (extra)
+          entry.notes = extra;
+
+        if (password)
+        {
+          entry.name = username;
+          entry.password = password;
+        }
+
+        mergeActions.push(setPassword(entry));
+      }
+    }
+    return Promise.all(mergeActions);
+  });
+}
+exports.import = import_;

--- a/lib/passwords.js
+++ b/lib/passwords.js
@@ -307,7 +307,8 @@ function importPasswordData(data)
 {
   let importers = [
     require("./importers/default"),
-    require("./importers/legacy")
+    require("./importers/legacy"),
+    require("./importers/lastPass")
   ];
 
   function setRaw(key, value)

--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -134,3 +134,8 @@ autolock_title = Enable auto-lock
 autolock_description = Lock passwords automatically when the panel is closed
 autolock_delay_title = Auto-lock delay
 autolock_delay_description = Interval in minutes after which the passwords should be locked
+
+# lastpass importer
+csv-unclosed-quote = Syntax error, could not find end of a quoted value.
+csv-wrong-number-of-values = Line {1}: Wrong number of values for entry. Saw {2}, but expected {3}.
+skipped-entry-missing-url = Entry with name {1} was skipped since it didn't have a valid URL.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
       "eol-last": "error",
       "indent": [
         "error",
-        2
+        2,
+        {
+          "SwitchCase": 1
+        }
       ],
       "key-spacing": "error",
       "keyword-spacing": "error",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
       "keyword-spacing": "error",
       "linebreak-style": "error",
       "new-parens": "error",
+      "no-empty": [
+        "error",
+        {
+          "allowEmptyCatch": true
+        }
+      ],
       "no-spaced-func": "error",
       "no-trailing-spaces": "error",
       "no-var": "error",

--- a/test/passwords.js
+++ b/test/passwords.js
@@ -1225,10 +1225,10 @@ exports.testLastPassImport = function(test)
   }).then(allPasswords =>
   {
     test.deepEqual(allPasswords, {
-      "easypasswords.invalid": {
-        site: "easypasswords.invalid",
+      "name": {
+        site: "name",
         passwords: [{
-          site: "easypasswords.invalid",
+          site: "name",
           type: "stored",
           name: "u",
           password: "secret123"
@@ -1272,10 +1272,10 @@ exports.testLastPassImport = function(test)
         }],
         aliases: []
       },
-      "easypasswords.invalid": {
-        site: "easypasswords.invalid",
+      "name": {
+        site: "name",
         passwords: [{
-          site: "easypasswords.invalid",
+          site: "name",
           type: "stored",
           name: "u",
           password: "secret123"

--- a/test/passwords.js
+++ b/test/passwords.js
@@ -1203,15 +1203,13 @@ exports.testLastPassImport = function(test)
       ["", "user", "password", "note", "dcom", "", ""],
       ["", "user", "password", "note", "e.com/path", "", ""],
       ["", "user", "password", "note", "This is f.com", "", ""],
-      ["", "user", "password", "note", ".com", "", ""],
-      ["", "user", "password", "note", ".", "", ""],
       ["http://sn", "user", "password", "note", "g.com", "", ""],
       ["http://www.h.com.", "user", "password", "note", "", "", ""],
       ["http://i.com", "", "", "note", "name", "", ""],
       ["http://j.com", "", "password", "note", "name", "", ""],
       ["http://k.com", "", "password", "", "name", "", ""],
       ["http://l.com", "user", "", "", "name", "", ""],
-      ["https://m.m.com/path?query", "user", "password", "before\"in\nside\"\"&amp;&lt;&gt;\"after", "name", "", ""]
+      ["https://m.m.com/path?query", "user", "password", "before\"in\nside\"\"&amp;&lt;&gt;\"after&amp;lt;", "name", "", ""]
     ]));
   }).then(() =>
   {
@@ -1226,7 +1224,7 @@ exports.testLastPassImport = function(test)
           type: "stored",
           name: "user",
           password: "password",
-          notes: "beforein\nside\"&<>after"
+          notes: "beforein\nside\"&<>after&lt;"
         }],
         aliases: []
       },

--- a/test/passwords.js
+++ b/test/passwords.js
@@ -1240,7 +1240,8 @@ exports.testLastPassImport = function(test)
         passwords: [{
           site: "foo.example.com",
           type: "stored",
-          notes: "Notes"
+          notes: "Notes",
+          name: "anotheruser"
         }, {
           site: "foo.example.com",
           type: "stored",
@@ -1265,8 +1266,8 @@ exports.testLastPassImport = function(test)
         passwords: [{
           site: "example.com",
           type: "stored",
-          notes: "\"",
           name: "&\n",
+          notes: "\"",
           password: ","
         }],
         aliases: []
@@ -1286,12 +1287,13 @@ exports.testLastPassImport = function(test)
         passwords: [{
           site: "foo.example.com",
           type: "stored",
+          name: "anotheruser",
           notes: "Notes"
         }, {
           site: "foo.example.com",
           type: "stored",
-          notes: "some\nnotes\nyada",
           name: "user",
+          notes: "some\nnotes\nyada",
           password: "password"
         }],
         aliases: []


### PR DESCRIPTION
This is a rebased version of  #53, there are still some FIXME comments which need to be dealt with but it's working.

Questions:
 - I throw away the name of the LastPass entry (except in the special case of a secure note with no associated username or URL). That seems like a shame but I don't know what else we can do.
 - I ignore the case of there being multiple entries with the same domain + username, hoping that `setPassword` is clever enough to thrown an error / do something smart. But if that's not the case we'll be silently losing entries! I've run out of time for today to test / investigate further.